### PR TITLE
Update readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ On the client-side, create an initial message, and then transmit it to the serve
 
     while (msg !== null) {
         val response = <queryServer>(msg);
-        val (newMsg, have, need) = ne.reconcile(msg);
+        val result : ReconciliationResult = neServer.reconcile(msgClient)
+        val newMsg = result.msgToString()
+        val have = result.needIds
+        val need = result.sendIds
         msg = newMsg;
         // handle have/need (there may be duplicates from previous calls to reconcile())
     }

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ On the client-side, create an initial message, and then transmit it to the serve
     while (msg !== null) {
         val response = <queryServer>(msg);
         val result : ReconciliationResult = neServer.reconcile(msgClient)
-        val newMsg = result.msgToString()
         val have = result.needIds
         val need = result.sendIds
-        msg = newMsg;
+        
+        msg = result.msg;
         // handle have/need (there may be duplicates from previous calls to reconcile())
     }
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ First, you need to create a storage instance. Currently only `Vector` is impleme
 Add all the items in your collection with `insert(timestamp, hash)` and call `seal()`
 
     StorageVector().apply {
-        insert(1678011277, "eb6b05c2e3b008592ac666594d78ed83e7b9ab30f825b9b08878128f7500008c".hexToByteArray())
-        insert(1678011278, "39b916432333e069a4386917609215cc688eb99f06fed01aadc29b1b4b92d6f0".hexToByteArray())
-        insert(1678011279, "abc81d58ebe3b9a87100d47f58bf15e9b1cbf62d38623f11d0f0d17179f5f3ba".hexToByteArray())
+        insert(1678011277, "eb6b05c2e3b008592ac666594d78ed83e7b9ab30f825b9b08878128f7500008c")
+        insert(1678011278, "39b916432333e069a4386917609215cc688eb99f06fed01aadc29b1b4b92d6f0")
+        insert(1678011279, "abc81d58ebe3b9a87100d47f58bf15e9b1cbf62d38623f11d0f0d17179f5f3ba")
 
         seal()
     }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ On the client-side, create an initial message, and then transmit it to the serve
 
     while (msg !== null) {
         val response = <queryServer>(msg);
-        val result : ReconciliationResult = neServer.reconcile(msgClient)
+        val result = ne.reconcile(msgClient)
         val have = result.needIds
         val need = result.sendIds
         


### PR DESCRIPTION
A couple of fixes to the README example:

- insert(... 2nd input is String not ByteArray
- ne.reconcile(msgClient) variable names are different and the internal structure does not allow destructuring