### PR TITLE
Add macOS and Windows platform support to Negentropy

### DIFF
--- a/negentropy/build.gradle.kts
+++ b/negentropy/build.gradle.kts
@@ -24,7 +24,10 @@ kotlin {
     iosX64()
     iosArm64()
     iosSimulatorArm64()
+    macosX64()
+    macosArm64()
     linuxX64()
+    mingwX64()
 
     sourceSets {
         val commonMain by getting {
@@ -77,7 +80,7 @@ mavenPublishing {
 
     pom {
         name = "Negentropy Library for Kotlin Multiplatform"
-        description = "Negentropy library ported to Kotlin/Multiplatform for JVM, Android, iOS & Linux"
+        description = "Negentropy library ported to Kotlin/Multiplatform for JVM, Android, iOS, macOS, Linux & Windows"
         inceptionYear = "2024"
         url = "https://github.com/vitorpamplona/kmp-negentropy/"
         licenses {


### PR DESCRIPTION
## Summary
Extended Negentropy's Kotlin Multiplatform support to include macOS and Windows platforms, in addition to the existing JVM, Android, iOS, and Linux targets.

## Key Changes
- Added `macosX64()` and `macosArm64()` targets to support both Intel and Apple Silicon macOS architectures
- Added `mingwX64()` target to support Windows (x64) platform
- Updated the library description in the POM to reflect the newly supported platforms: "Negentropy library ported to Kotlin/Multiplatform for JVM, Android, iOS, macOS, Linux & Windows"

## Details
These changes enable developers to use the Negentropy library on macOS and Windows platforms through Kotlin Multiplatform, expanding the library's cross-platform capabilities. The additions follow the existing pattern of platform declarations in the build configuration.

https://claude.ai/code/session_01Jrfwsux6RN9Qogy2YUNMCi